### PR TITLE
增加通过主键查询非逻辑删方法

### DIFF
--- a/src/test/java/com/itfsw/mybatis/generator/plugins/LogicalDeletePluginTest.java
+++ b/src/test/java/com/itfsw/mybatis/generator/plugins/LogicalDeletePluginTest.java
@@ -123,6 +123,27 @@ public class LogicalDeletePluginTest {
     }
 
     /**
+     * 测试 selectNotDeletedByPrimaryKey
+     */
+    @Test
+    public void testSelectNotDeletedByPrimaryKey() throws IOException, XMLParserException, InvalidConfigurationException, InterruptedException, SQLException {
+        MyBatisGeneratorTool tool = MyBatisGeneratorTool.create("scripts/LogicalDeletePlugin/mybatis-generator.xml");
+        tool.generate(new AbstractShellCallback() {
+            @Override
+            public void reloadProject(SqlSession sqlSession, ClassLoader loader, String packagz) throws Exception{
+                ObjectUtil tbMapper = new ObjectUtil(sqlSession.getMapper(loader.loadClass(packagz + ".TbMapper")));
+
+                // 验证sql
+                String sql = SqlHelper.getFormatMapperSql(tbMapper.getObject(), "selectNotDeletedByPrimaryKey", 3L);
+                Assert.assertEquals(sql, "select id, del_flag, ts_1, ts_3, ts_4 from tb where id = 3 and del_flag <> 1");
+                // 验证执行
+                Object result = tbMapper.invoke("selectNotDeletedByPrimaryKey", 3L);
+                Assert.assertEquals(result, null);
+            }
+        });
+    }
+
+    /**
      * 测试关联生成的方法和常量
      */
     @Test


### PR DESCRIPTION
对于有逻辑删的数据库而言，如果通过主键查询，不能过滤掉逻辑删的数量，查询结果是不对的。
所以增加通过主键查询非逻辑删方法，同时增加了test用例