### PR TITLE
TargetPackagePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Maven引用：
 <dependency>
   <groupId>com.itfsw</groupId>
   <artifactId>mybatis-generator-plugin</artifactId>
-  <version>1.3.6</version>
+  <version>1.3.7</version>
 </dependency>
 ```
 ---------------------------------------
@@ -100,7 +100,7 @@ targetCompatibility = 1.8
 
 
 def mybatisGeneratorCore = 'org.mybatis.generator:mybatis-generator-core:1.3.7'
-def itfswMybatisGeneratorPlugin = 'com.itfsw:mybatis-generator-plugin:1.3.6'
+def itfswMybatisGeneratorPlugin = 'com.itfsw:mybatis-generator-plugin:1.3.7'
 
 mybatisGenerator {
   verbose = false
@@ -1632,8 +1632,8 @@ public class Test {
                 .id(102)
                 .field4(new Date())
                 .build()
-                .increment(Tb.Column.field1.inc(1)) // 字段1 统计增加1
-                .increment(Tb.Column.field2.dec(2)); // 字段2 统计减去2
+                .increment(Tb.Increment.field1.inc(1)) // 字段1 统计增加1
+                .increment(Tb.Increment.field2.dec(2)); // 字段2 统计减去2
         // 更新操作，可以是 updateByExample, updateByExampleSelective, updateByPrimaryKey
         // , updateByPrimaryKeySelective, upsert, upsertSelective等所有涉及更新的操作
         this.tbMapper.updateByPrimaryKey(tb);

--- a/README.md
+++ b/README.md
@@ -1674,4 +1674,4 @@ TargetPackagePlugin可用为一个表的ModelClass、ClientClass、SQLMap分别�
 </xml>
 ```
 
-生成的三类文件的包名分别为<javaModelGenerator>、<javaClientGenerator>、<sqlMapGenerator>标签中配置的`targetPackage`属性与<table>标签中配置的`xxxTargetPackage`属性的拼接结果
+生成的三类文件的包名分别为`<javaModelGenerator>`、`<javaClientGenerator>`、`<sqlMapGenerator>`标签中配置的`targetPackage`属性与`<table>`标签中配置的`xxxTargetPackage`属性的拼接结果

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.itfsw</groupId>
     <artifactId>mybatis-generator-plugin</artifactId>
-    <version>1.3.7-SNAPSHOT</version>
+    <version>1.3.7</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.itfsw</groupId>
     <artifactId>mybatis-generator-plugin</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
有的项目组要求按照业务逻辑划分子包，在业务子包中进一步分controller、service, entity、mapper...., ModelClass需要生成在entity包中，ClientClass需要生成在mapper包中，而SQLMAP文件需要在/src/map/xxx/文件夹下，`targetPackage`属性和`domainObjectName`无法实现
TargetPackagePlugin可用为一个表的ModelClass、ClientClass、SQLMap分别设置不同的targetPackage

插件：
```xml
<xml>
    <plugin type="com.itfsw.mybatis.generator.plugins.TargetPackagePlugin"/>
    
    <table schema="FG_DB" tableName="USER">
        <property name="modelTargetPackage" value="account.entity" />
        <property name="clientTargetPackage" value="account.mapper"/>
        <property name="sqlMapTargetPackage" value="account" />
    </table>
</xml>
```

生成的三类文件的包名分别为`<javaModelGenerator>`、`<javaClientGenerator>`、`<sqlMapGenerator>`标签中配置的`targetPackage`属性与`<table>`标签中配置的`xxxTargetPackage`属性的拼接结果
